### PR TITLE
feat: adjust delay for new esp-idf

### DIFF
--- a/main/esp32_i2c_adxl345_main.c
+++ b/main/esp32_i2c_adxl345_main.c
@@ -20,7 +20,7 @@ static void sensorTask(void *pvParameters) {
 	while (1) {
 		getAccelerometerData(acc);
 		ESP_LOGI(TAG,"X=%d,Y=%d,Z=%d\n",(int8_t)acc[0],(int8_t)acc[1],(int8_t)acc[2]);
-		vTaskDelay(1000 / portTICK_RATE_MS);
+		vTaskDelay(1000 / portTICK_PERIOD_MS);
 	}
 
 }


### PR DESCRIPTION
Latest esp-idf doesn't specify portTICK_RATE_MS. It was replaced with portTICK_PERIOD_MS. Loading this lib on new esp-idf will render the lib non-compilable.